### PR TITLE
Added flush support for larger responses (>16kb)

### DIFF
--- a/OpenThingsFramework.cpp
+++ b/OpenThingsFramework.cpp
@@ -210,7 +210,7 @@ void OpenThingsFramework::webSocketCallback(WStype_t type, uint8_t *payload, siz
         fillResponse(request, res);
 
         if (res.isValid()) {
-          webSocket->sendTXT((uint8_t*)res.toString(), res.getLength(), true, false);
+          webSocket->sendTXT(res.toString(), res.getLength(), true, false);
         } else {
           DEBUG(Serial.println(F("An error occurred building response string"));)
           StringBuilder builder(100);

--- a/OpenThingsFramework.cpp
+++ b/OpenThingsFramework.cpp
@@ -210,7 +210,7 @@ void OpenThingsFramework::webSocketCallback(WStype_t type, uint8_t *payload, siz
         fillResponse(request, res);
 
         if (res.isValid()) {
-          webSocket->sendTXT(res.toString(), res.getLength());
+          webSocket->sendTXT((uint8_t*)res.toString(), res.getLength(), true, false);
         } else {
           DEBUG(Serial.println(F("An error occurred building response string"));)
           StringBuilder builder(100);

--- a/OpenThingsFramework.cpp
+++ b/OpenThingsFramework.cpp
@@ -149,18 +149,18 @@ void OpenThingsFramework::localServerLoop() {
   }
 
   //Serial.println(F("Filling response"));
-  Response res = Response();
+  Response res = Response(localClient);
   fillResponse(request, res);
 
   if(bodyBuffer) delete[] bodyBuffer;
   //Serial.println(F("Sending response"));
   if (res.isValid()) {
     char *responseString = res.toString();
-    DEBUG(Serial.printf((char *) F("Response message is: %s\n"), responseString);)
+    //DEBUG(Serial.printf((char *) F("Response message is: %s\n"), responseString);)
     localClient->print(responseString);
   } else {
     localClient->print(F("HTTP/1.1 500 OTF error\r\nResponse string could not be built\r\n"));
-    DEBUG(Serial.println(F("An error occurred while building the response string."));)
+    //DEBUG(Serial.println(F("An error occurred while building the response string."));)
   }
 
   // Get a new client to indicate that the previous client is no longer needed.
@@ -205,7 +205,7 @@ void OpenThingsFramework::webSocketCallback(WStype_t type, uint8_t *payload, siz
         requestId[ID_LENGTH] = '\0';
 
         Request request(&message[HEADER_LENGTH], length - HEADER_LENGTH, true);
-        Response res = Response();
+        Response res = Response(webSocket);
         res.bprintf(F("RES: %s\r\n"), requestId);
         fillResponse(request, res);
 

--- a/Request.cpp
+++ b/Request.cpp
@@ -118,7 +118,7 @@ Request::Request(char *str, size_t length, bool cloudRequest) {
     }
   }
 
-  // Parse headers until "\r\n\r\n" is encountered (indicates the end of headers) or the end of the string is reached (caused by invalid requests).
+  // Parse headers until "\r\n\r\n" is encountered (indicates the end of headers) or the end of the string is reached (caused b"y invalid requests).
   while (index < length && str[index] != '\r') {
     if (!parseHeader(str, length, index, headers)) {
       // Reject the request if an error occurs while parsing headers.

--- a/Response.cpp
+++ b/Response.cpp
@@ -109,7 +109,7 @@ void Response::flush() {
   if (localClient)
     localClient->print(responseString);
   else if (webSocket)
-    webSocket->sendTXT(responseString, strlen(responseString));
+    webSocket->sendTXT(responseString, strlen(responseString), false, false);
 
   reset();
 }

--- a/Response.cpp
+++ b/Response.cpp
@@ -103,3 +103,13 @@ void Response::writeBodyChunk(const __FlashStringHelper *const format, ...) {
   bprintf(format, args);
   va_end(args);
 }
+
+void Response::flush() {
+  char *responseString = toString();
+  if (localClient)
+    localClient->print(responseString);
+  else if (webSocket)
+    webSocket->sendTXT(responseString, strlen(responseString));
+
+  reset();
+}

--- a/Response.cpp
+++ b/Response.cpp
@@ -78,7 +78,7 @@ void Response::writeBodyChunk(char *const format, ...) {
     return;
   }
   if (responseStatus != BODY_WRITTEN) {
-    bprintf((char *) "\r\n");
+    append("\r\n");
     responseStatus = BODY_WRITTEN;
   }
 
@@ -94,7 +94,7 @@ void Response::writeBodyChunk(const __FlashStringHelper *const format, ...) {
     return;
   }
   if (responseStatus != BODY_WRITTEN) {
-    bprintf((char *) "\r\n");
+    append("\r\n");
     responseStatus = BODY_WRITTEN;
   }
 
@@ -109,7 +109,7 @@ void Response::flush() {
   if (localClient)
     localClient->print(responseString);
   else if (webSocket)
-    webSocket->sendTXT((uint8_t*)responseString, strlen(responseString), false, false);
+    webSocket->sendTXT(responseString, getLength(), false, false);
 
   reset();
 }

--- a/Response.cpp
+++ b/Response.cpp
@@ -109,7 +109,7 @@ void Response::flush() {
   if (localClient)
     localClient->print(responseString);
   else if (webSocket)
-    webSocket->sendTXT(responseString, strlen(responseString), false, false);
+    webSocket->sendTXT((uint8_t*)responseString, strlen(responseString), false, false);
 
   reset();
 }

--- a/Response.h
+++ b/Response.h
@@ -2,6 +2,8 @@
 #define OTF_RESPONSE_H
 
 #include "StringBuilder.h"
+#include "LocalServer.h"
+#include "WebSocketsClient.h"
 
 #include <Arduino.h>
 
@@ -21,9 +23,12 @@ namespace OTF {
       BODY_WRITTEN
     };
     ResponseStatus responseStatus = CREATED;
+    LocalClient *localClient = nullptr;
+    WebSocketsClient *webSocket = nullptr;
 
-    Response() : StringBuilder(RESPONSE_BUFFER_SIZE) {}
+    Response(WebSocketsClient *pwebSocket) : StringBuilder(RESPONSE_BUFFER_SIZE) {webSocket = pwebSocket;}
 
+    Response(LocalClient *plocalClient) : StringBuilder(RESPONSE_BUFFER_SIZE) {localClient = plocalClient;}
 
   public:
     static const size_t MAX_RESPONSE_LENGTH = RESPONSE_BUFFER_SIZE;
@@ -58,6 +63,8 @@ namespace OTF {
     void writeBodyChunk(char *format, ...);
 
     void writeBodyChunk(const __FlashStringHelper *const format, ...);
+
+    void flush();
   };
 }// namespace OTF
 #endif

--- a/Response.h
+++ b/Response.h
@@ -8,7 +8,7 @@
 #include <Arduino.h>
 
 // The maximum possible size of response messages.
-#define RESPONSE_BUFFER_SIZE 18000
+#define RESPONSE_BUFFER_SIZE 10*1024
 
 namespace OTF {
 

--- a/StringBuilder.cpp
+++ b/StringBuilder.cpp
@@ -56,3 +56,12 @@ size_t StringBuilder::getLength() const {
 bool StringBuilder::isValid() {
   return valid;
 }
+
+bool StringBuilder::willFit(size_t size) {
+  return size + length <= maxLength;
+}
+
+void StringBuilder::reset() {
+  length = 0;
+  buffer[0] = 0;
+}

--- a/StringBuilder.cpp
+++ b/StringBuilder.cpp
@@ -58,10 +58,34 @@ bool StringBuilder::isValid() {
 }
 
 bool StringBuilder::willFit(size_t size) {
-  return size + length <= maxLength;
+  return size + length + 1 < maxLength;
 }
 
 void StringBuilder::reset() {
   length = 0;
   buffer[0] = 0;
+  valid = true;
 }
+
+void StringBuilder::append(const char *txt, size_t size) {
+  if (!valid || !willFit(size)) {
+    valid = false;
+    return;
+  }
+  strncpy(&buffer[length], txt, size);
+  length += size;
+  buffer[length] = 0;
+}
+
+void StringBuilder::append(const char *txt) {
+  append(txt, strlen(txt));
+}
+
+void StringBuilder::append(const __FlashStringHelper *const txt, size_t size) {
+  append((char *)txt, size);
+}
+
+void StringBuilder::append(const __FlashStringHelper *const txt) {
+  append((char *)txt);
+}
+

--- a/StringBuilder.h
+++ b/StringBuilder.h
@@ -37,6 +37,14 @@ namespace OTF {
 
     void bprintf(const __FlashStringHelper *const format, ...);
 
+    void append(const char *txt, size_t size);
+
+    void append(const char *txt);
+
+    void append(const __FlashStringHelper *const txt, size_t size);
+
+    void append(const __FlashStringHelper *const txt);
+
     /**
      * Returns the null-terminated represented string stored in the underlying buffer.
      * @return The null-terminated represented string stored in the underlying buffer.

--- a/StringBuilder.h
+++ b/StringBuilder.h
@@ -51,6 +51,10 @@ namespace OTF {
      * be used.
      */
     bool isValid();
+
+    bool willFit(size_t size);
+
+    void reset();
   };
 }// namespace OTF
 


### PR DESCRIPTION
With this enhancement opensprinkler and other system can easily output more data. 
you need just to call res.willfit(size to add); and if its false, call res.flush(); before adding new result data

For example opensprinkler_server_cpp.send_packet:
	if (!res.willFit(bfill.position()))
		res.flush(); 
	res.writeBodyChunk((char *)"%s",ether_buffer);