### PR TITLE
Explicitly including <string> OpenThingsFramework.cpp

### DIFF
--- a/OpenThingsFramework.cpp
+++ b/OpenThingsFramework.cpp
@@ -1,5 +1,8 @@
 #include "OpenThingsFramework.h"
 #include "StringBuilder.h"
+#if defined(DEBUG)
+#include <string>
+#endif
 
 // The timeout for reading and parsing incoming requests.
 #define WIFI_CONNECTION_TIMEOUT 1500


### PR DESCRIPTION
In DEBUG mode, there is a reference to std::string.  Depending on what version of the espressif8266 version being compiled against, this may not be available.  In particular, std::string is included in the 2.x build toolchain, but not in the 3.x or 4.x, so it causes a compile error unless it's explicitly included.

The line that needs this is https://github.com/OpenThingsIO/OpenThings-Framework-Firmware-Library/blob/c27fd34d9c2babb1c0bdbb406c06e75a85db7424/OpenThingsFramework.cpp#L235
